### PR TITLE
Set light theme by default and refine UI

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -4,10 +4,10 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { CalendarDays, Clock, Users, ArrowRight } from 'lucide-react'
 
-const Value = ({icon, title, desc}:{icon: any, title: string, desc: string}) => (
+const Value = ({ icon, title, desc }: { icon: any, title: string, desc: string }) => (
   <div className="card">
-    <div className="flex items-center gap-3">
-      <div className="p-2 rounded-xl bg-neutral-100 dark:bg-white/10">{icon}</div>
+    <div className="flex items-start gap-3">
+      <div className="p-2 rounded-xl bg-neutral-100 dark:bg-white/10 flex-shrink-0">{icon}</div>
       <div>
         <p className="font-medium">{title}</p>
         <p className="text-sm text-neutral-600 dark:text-neutral-300">{desc}</p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="pt-BR" suppressHydrationWarning>
       <body>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
           <Header />
           <main>{children}</main>
           <footer className="border-t border-neutral-200 dark:border-white/10 mt-16">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,10 +7,9 @@ export default function Header() {
   return (
     <header className="sticky top-0 z-20 bg-neutral-50/80 dark:bg-brand-900/70 backdrop-blur border-b border-neutral-200/60 dark:border-white/10">
       <div className="container py-4 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="h-8 w-8 rounded-xl bg-black text-white grid place-items-center font-bold dark:bg-white dark:text-black">SR</div>
-          <span className="font-semibold tracking-tight">suareserva.online</span>
-        </div>
+        <Link href="/" className="font-semibold tracking-tight">
+          suareserva.online
+        </Link>
         <nav className="text-sm flex items-center gap-2">
           <Link className="px-3 py-1.5 rounded-xl hover:bg-neutral-200/60 dark:hover:bg-white/10" href="/">Início</Link>
           <Link className="px-3 py-1.5 rounded-xl hover:bg-neutral-200/60 dark:hover:bg-white/10" href="/admin">Painel</Link>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -2,17 +2,25 @@
 'use client'
 import { useTheme } from 'next-themes'
 import { Moon, Sun } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
   const isDark = theme === 'dark'
+
   return (
     <button
       aria-label="Toggle theme"
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
       className="px-3 py-1.5 rounded-xl hover:bg-neutral-200/60 dark:hover:bg-white/10 text-sm inline-flex items-center gap-2"
     >
-      {isDark ? <Sun size={16}/> : <Moon size={16}/>}
+      {isDark ? <Sun size={16} /> : <Moon size={16} />}
       {isDark ? 'Claro' : 'Escuro'}
     </button>
   )


### PR DESCRIPTION
## Summary
- Default to light theme and disable system preference
- Fix first click issue in theme toggle
- Realign home cards layout
- Simplify header branding to text-only logo

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68963a1317a8832390732b582d356855