### PR TITLE
feat: add time slots preview component

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { CalendarDays, Clock, Users, ArrowRight } from 'lucide-react'
+import SlotsPreview from '@/components/SlotsPreview'
 
 const Value = ({ icon, title, desc }: { icon: any, title: string, desc: string }) => (
   <div className="card">
@@ -38,8 +39,8 @@ export default function Page() {
           <div className="card">
             <div className="rounded-2xl bg-neutral-900 text-white p-6 dark:bg-brand-700">
               <p className="text-sm opacity-80">Página pública</p>
-              <div className="mt-3 h-48 rounded-xl bg-neutral-800 grid place-items-center dark:bg-brand-900/40">
-                <span className="text-neutral-400">calendário/slots preview</span>
+              <div className="mt-3 h-48 rounded-xl bg-neutral-800 p-4 dark:bg-brand-900/40">
+                <SlotsPreview />
               </div>
             </div>
           </div>
@@ -47,7 +48,9 @@ export default function Page() {
             <div>
               <p className="text-sm font-medium">Serviço: Corte + Barba</p>
               <p className="text-xs text-neutral-600 dark:text-neutral-300">R$ 89 · 45 min</p>
-              <div className="mt-3 h-16 rounded-xl bg-neutral-100 grid place-items-center text-neutral-500 text-xs dark:bg-white/10">horários</div>
+              <div className="mt-3 rounded-xl bg-neutral-100 p-3 dark:bg-white/10">
+                <SlotsPreview times={["09:00","09:45","10:30"]} />
+              </div>
             </div>
           </div>
         </motion.div>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Plus, Trash2, LinkIcon, Settings } from 'lucide-react'
+import SlotsPreview from '@/components/SlotsPreview'
 
 type Service = { name: string; duration: number; price: number }
 
@@ -123,7 +124,9 @@ export default function Page() {
                 </div>
                 <div className="text-xs bg-neutral-100 px-3 py-1.5 rounded-xl dark:bg-white/10">/{biz.handle}</div>
               </div>
-              <div className="mt-3 h-24 rounded-xl bg-neutral-100 grid place-items-center text-neutral-500 text-xs dark:bg-white/10">slots preview</div>
+              <div className="mt-3 h-24 rounded-xl bg-neutral-100 p-3 dark:bg-white/10">
+                <SlotsPreview />
+              </div>
             </div>
           </motion.div>
         </div>

--- a/components/SlotsPreview.tsx
+++ b/components/SlotsPreview.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function SlotsPreview({ times = ['09:00','09:45','10:30','11:15','14:00','14:45','15:30'] }: { times?: string[] }) {
+  return (
+    <div className="grid grid-cols-3 gap-2 text-xs">
+      {times.map((t) => (
+        <div
+          key={t}
+          className="rounded-xl border border-neutral-200 bg-neutral-50 py-2 text-center text-neutral-900 dark:border-white/10 dark:bg-white/10 dark:text-white"
+        >
+          {t}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create reusable `SlotsPreview` component
- show time slots preview on home and admin pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68963cbe92a48323a22067d8f29fd031